### PR TITLE
add application/x-download and binary/octet-stream to blacklist

### DIFF
--- a/background.js
+++ b/background.js
@@ -14,7 +14,9 @@ function guessContentType(fileName) {
     }[fileName.split('.').pop()];
 }
 function isBlacklistedContentType(contentType) {
-    return /^application\/octet-?stream$/i.test(contentType);
+    return /^application\/octet-?stream$/i.test(contentType)
+        || /^binary\/octet-?stream$/i.test(contentType)
+        || /^application\/x?-?download$/i.test(contentType);
 }
 browser.webRequest.onHeadersReceived.addListener(
     function (request) {


### PR DESCRIPTION
These exist in the wild, e.g. in #1 (`binary/octet-stream`) or at the german post office (`application/x-download`).