### PR TITLE
Add json type

### DIFF
--- a/background.js
+++ b/background.js
@@ -11,6 +11,7 @@ function guessContentType(fileName) {
         patch: "text/plain",
         torrent: "text/plain",
         mp3: "audio/mpeg",
+        json: "application/json"
     }[fileName.split('.').pop()];
 }
 function isBlacklistedContentType(contentType) {


### PR DESCRIPTION
If a JSON file is sent as `text/plain` firefox doesn't format it in the browser as it does with `application/json`